### PR TITLE
fix: implement working theme toggle for dark/light mode

### DIFF
--- a/apps/web/src/components/layout/theme-provider.tsx
+++ b/apps/web/src/components/layout/theme-provider.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import type * as React from "react";
+import { ThemeProvider as NextThemesProvider } from "next-themes";
+import type { ThemeProviderProps } from "next-themes/dist/types";
 
-export function ThemeProvider({ children }: { children: React.ReactNode }) {
-	return <>{children}</>;
+export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
+	return <NextThemesProvider {...props}>{children}</NextThemesProvider>;
 }

--- a/apps/web/src/components/layout/theme-toggle.tsx
+++ b/apps/web/src/components/layout/theme-toggle.tsx
@@ -8,12 +8,14 @@ import {
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Laptop, Moon, Sun } from "lucide-react";
+import { useTheme } from "next-themes";
 import * as React from "react";
 
 export function ThemeToggle() {
+	const { setTheme, theme } = useTheme();
 	// To avoid a hydration error caused by mismatched server/client rendering,
 	// we wait for the component to mount before using `theme` from `next-themes`,
-	// since it relies on localStorage and is not available during SSR.s
+	// since it relies on localStorage and is not available during SSR.
 	const [mounted, setMounted] = React.useState(false);
 
 	React.useEffect(() => {
@@ -26,7 +28,13 @@ export function ThemeToggle() {
 		<DropdownMenu>
 			<DropdownMenuTrigger asChild>
 				<Button variant="ghost" size="icon" className="h-8 w-8 shrink-0">
-					<Sun className="h-4 w-4" />
+					{theme === "dark" ? (
+						<Moon className="h-4 w-4" />
+					) : theme === "light" ? (
+						<Sun className="h-4 w-4" />
+					) : (
+						<Laptop className="h-4 w-4" />
+					)}
 					<span className="sr-only">Toggle theme</span>
 				</Button>
 			</DropdownMenuTrigger>


### PR DESCRIPTION
- Update ThemeProvider to use next-themes library
- Add useTheme hook to ThemeToggle component
- Display correct icon based on current theme selection
- Support light, dark, and system preference modes

🤖 Generated with [Claude Code](https://claude.ai/code)